### PR TITLE
Progress SDF refactor

### DIFF
--- a/Assets/Scripts/Game/DaggerfallUI.cs
+++ b/Assets/Scripts/Game/DaggerfallUI.cs
@@ -331,14 +331,6 @@ namespace DaggerfallWorkshop.Game
 
         void Update()
         {
-            // Toggle font rendering between classic and SDF using LeftShift+F
-            if ((Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift)) && Input.GetKeyDown(KeyCode.F11))
-            {
-                DaggerfallUnity.Settings.SDFFontRendering = !DaggerfallUnity.Settings.SDFFontRendering;
-                DaggerfallUnity.Settings.SaveSettings();
-                //Debug.LogFormat("SDFFontRendering={0}", DaggerfallUnity.Settings.SDFFontRendering.ToString());
-            }
-
             // HUD is always first window on stack when ready
             if (dfUnity.IsPathValidated && !hudSetup)
             {

--- a/Assets/Scripts/Game/UserInterface/ListBox.cs
+++ b/Assets/Scripts/Game/UserInterface/ListBox.cs
@@ -318,7 +318,6 @@ namespace DaggerfallWorkshop.Game.UserInterface
 
                     currentLine += label.NumTextLines;                
                     label.StartCharacterIndex = horizontalScrollIndex;
-                    label.RefreshClassicLayout();
 
                     DecideTextColor(label, i);
 
@@ -346,7 +345,6 @@ namespace DaggerfallWorkshop.Game.UserInterface
                         label.StartCharacterIndex = horizontalScrollIndex;
                     else if (horizontalScrollMode == HorizontalScrollModes.PixelWise)
                         x = -horizontalScrollIndex;
-                    label.RefreshClassicLayout();
 
                     DecideTextColor(label, i);
 

--- a/Assets/Scripts/Game/UserInterface/TextBox.cs
+++ b/Assets/Scripts/Game/UserInterface/TextBox.cs
@@ -334,7 +334,7 @@ namespace DaggerfallWorkshop.Game.UserInterface
             else
             {
                 width = GetCharacterWidthToCursor();
-                textCursor.Position = new Vector2(width / LocalScale.x, textOffset);
+                textCursor.Position = new Vector2(width, textOffset);
             }
             textCursor.BlinkOn();
         }
@@ -363,14 +363,14 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 }
             }
 
-            int totalWidth = (width + font.GlyphSpacing) * MaxCharacters;
+            float totalWidth = (width + font.GlyphSpacing) * MaxCharacters;
             return new Vector2(totalWidth, font.GlyphHeight);
         }
 
         // Calculate the current size
         private Vector2 CalculateCurrentSize()
         {
-            int width = 0;
+            float width = 0;
             byte[] asciiBytes;
             asciiBytes = Encoding.ASCII.GetBytes(text);
 

--- a/Assets/Scripts/Game/UserInterface/ToolTip.cs
+++ b/Assets/Scripts/Game/UserInterface/ToolTip.cs
@@ -220,8 +220,6 @@ namespace DaggerfallWorkshop.Game.UserInterface
                 float width = font.CalculateTextWidth(textRows[i], LocalScale);
                 if (width > widestRow)
                     widestRow = width;
-                if (font.IsSDFCapable)
-                    widestRow /= LocalScale.x;
             }
             previousSDFState = sdfState;
         }

--- a/Assets/StreamingAssets/Text/MainMenu.txt
+++ b/Assets/StreamingAssets/Text/MainMenu.txt
@@ -30,7 +30,7 @@ playerNudityInfo,           Allow nudity on paper doll
 clickToAttack,              Click to attack
 clickToAttackInfo,          Enable a simple click to trigger attacks
 sdfFontRendering,           SDF Font Rendering
-sdfFontRenderingInfo,       Enable for smooth fonts at high resolutions\rUse Shift+F11 to change anytime
+sdfFontRenderingInfo,       Enable for smooth fonts at high resolutions
 
 findArena2Tip,              Tip: Daggerfall contains a folder called 'arena2'
 foundArena2But,             Found 'arena2' but


### PR DESCRIPTION
Can no longer toggle classic/SDF font at runtime with Shift+F11. Classic and SDF no longer share same layout metrics so this is no longer worth supporting.
Started unifying TextLabel layout process to use a common process for both classic and SDF text. Helper methods will instead manage the difference at layout time.
Single-line text labels now support SDF fonts. Multi-line will be worked on next.
Developers should continue using classic text until refactor completed.